### PR TITLE
patch/curl: enable ECH support

### DIFF
--- a/patch/0006-curl-update-build.patch
+++ b/patch/0006-curl-update-build.patch
@@ -1,4 +1,4 @@
-From a09c3700cdd5bfba9440c5b00d55d8d0f7e93673 Mon Sep 17 00:00:00 2001
+From 0a7d48b66fa98bbe77b92015912e8df4666c5489 Mon Sep 17 00:00:00 2001
 From: zhongfly <11155705+zhongfly@users.noreply.github.com>
 Date: Wed, 13 May 2026 21:46:45 +0800
 Subject: curl: update build
@@ -6,8 +6,8 @@ Subject: curl: update build
 ---
  packages/CMakeLists.txt                       |  2 +-
  ...001-Skip-compiling-unnecessary-stuff.patch | 25 ---------
- packages/curl.cmake                           | 53 ++++++++++++++-----
- 3 files changed, 40 insertions(+), 40 deletions(-)
+ packages/curl.cmake                           | 54 ++++++++++++++-----
+ 3 files changed, 41 insertions(+), 40 deletions(-)
  delete mode 100644 packages/curl-0001-Skip-compiling-unnecessary-stuff.patch
 
 diff --git a/packages/CMakeLists.txt b/packages/CMakeLists.txt
@@ -58,10 +58,10 @@ index 1b0144e..0000000
 -2.15.0
 -
 diff --git a/packages/curl.cmake b/packages/curl.cmake
-index 5b73db3..54e07b3 100644
+index 5b73db3..492f739 100644
 --- a/packages/curl.cmake
 +++ b/packages/curl.cmake
-@@ -1,25 +1,50 @@
+@@ -1,25 +1,51 @@
  ExternalProject_Add(curl
      DEPENDS
 -        mbedtls
@@ -110,6 +110,7 @@ index 5b73db3..54e07b3 100644
 +        -DENABLE_THREADED_RESOLVER=ON
 +        -DUSE_WIN32_IDN=ON
 +        -DUSE_WINDOWS_SSPI=ON
++        -DUSE_ECH=ON
 +        -DUSE_HTTPSRR=ON
 +        -DUSE_SSLS_EXPORT=ON
 +        -DCURL_USE_PKGCONFIG=ON

--- a/patch/0007-c-ares-add-c-ares.patch
+++ b/patch/0007-c-ares-add-c-ares.patch
@@ -1,4 +1,4 @@
-From 1e33b8322824f7f817c4e2cf1fdd98bdcef344aa Mon Sep 17 00:00:00 2001
+From 7507b58480a27bebe08114bc56558a609830c858 Mon Sep 17 00:00:00 2001
 From: zhongfly <11155705+zhongfly@users.noreply.github.com>
 Date: Wed, 13 May 2026 22:18:54 +0800
 Subject: c-ares: add c-ares
@@ -55,7 +55,7 @@ index 0000000..755b8b8
 +force_rebuild_git(c-ares)
 +cleanup(c-ares install)
 diff --git a/packages/curl.cmake b/packages/curl.cmake
-index 54e07b3..59c4a5e 100644
+index 492f739..caf2211 100644
 --- a/packages/curl.cmake
 +++ b/packages/curl.cmake
 @@ -1,6 +1,7 @@

--- a/patch/0008-ngtcp2-nghttp3-nghttp2-add-ngtcp2-nghttp3-nghttp2.patch
+++ b/patch/0008-ngtcp2-nghttp3-nghttp2-add-ngtcp2-nghttp3-nghttp2.patch
@@ -1,4 +1,4 @@
-From b1e6a600844b6be70a2eb8df888b05c7c420e3ec Mon Sep 17 00:00:00 2001
+From 058faae0bfca90f76a2a9c97dd90fe5e4d277bda Mon Sep 17 00:00:00 2001
 From: zhongfly <11155705+zhongfly@users.noreply.github.com>
 Date: Wed, 13 May 2026 22:54:01 +0800
 Subject: ngtcp2,nghttp3,nghttp2: add ngtcp2,nghttp3,nghttp2
@@ -29,7 +29,7 @@ index f17b4f7..71816f0 100644
      libpsl
      curl
 diff --git a/packages/curl.cmake b/packages/curl.cmake
-index 59c4a5e..0f8c9aa 100644
+index caf2211..0fdf58e 100644
 --- a/packages/curl.cmake
 +++ b/packages/curl.cmake
 @@ -4,6 +4,9 @@ ExternalProject_Add(curl
@@ -42,7 +42,7 @@ index 59c4a5e..0f8c9aa 100644
          openssl
          zlib
          zstd
-@@ -36,13 +39,16 @@ ExternalProject_Add(curl
+@@ -36,6 +39,9 @@ ExternalProject_Add(curl
          -DENABLE_CURL_MANUAL=OFF
          -DENABLE_UNICODE=ON
          -DENABLE_THREADED_RESOLVER=ON
@@ -51,7 +51,8 @@ index 59c4a5e..0f8c9aa 100644
 +        -DUSE_NGTCP2=ON
          -DUSE_WIN32_IDN=ON
          -DUSE_WINDOWS_SSPI=ON
-         -DUSE_HTTPSRR=ON
+         -DUSE_ECH=ON
+@@ -43,7 +49,7 @@ ExternalProject_Add(curl
          -DUSE_SSLS_EXPORT=ON
          -DCURL_USE_PKGCONFIG=ON
          -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON


### PR DESCRIPTION
I didn't enable it earlier because Qt6 doesn't support openssl 4.0 yet.