### PR TITLE
patch/toolchain: disable problematic longjmp cfguard check

### DIFF
--- a/patch/0017-llvm-ld-add-no-guard-longjmp.patch
+++ b/patch/0017-llvm-ld-add-no-guard-longjmp.patch
@@ -1,0 +1,25 @@
+From 6b6fdfe1e3491807b8d41146cf47b004ad9b25f4 Mon Sep 17 00:00:00 2001
+From: _ <>
+Date: Sun, 2 Aug 2026 00:00:00 +0000
+Subject: [PATCH] llvm-ld: add --no-guard-longjmp
+
+---
+ toolchain/llvm/llvm-ld.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolchain/llvm/llvm-ld.in b/toolchain/llvm/llvm-ld.in
+index e5d1608..a84ff42 100644
+--- a/toolchain/llvm/llvm-ld.in
++++ b/toolchain/llvm/llvm-ld.in
+@@ -8,7 +8,7 @@ FLAGS="$FLAGS --thinlto-cache-dir=@MINGW_INSTALL_PREFIX@/thinlto --thinlto-cache
+ if [ "$CONF" == "1" ]; then
+     SKIP_OPT="-O0 --lto-O0 --lto-CGO0 --no-gc-sections --no-guard-cf --build-id=none"
+ else
+-    FLAGS="$FLAGS -O3 --lto-O3 --lto-CGO3 -s -Xlink=-release"
++    FLAGS="$FLAGS -O3 --lto-O3 --lto-CGO3 -s -Xlink=-release --no-guard-longjmp"
+     if [ "$GC" != "0" ]; then
+         LLD_GC="--gc-sections --icf=safe"
+     fi
+-- 
+2.55.0
+


### PR DESCRIPTION
caused crash like https://github.com/mpv-player/mpv/issues/18332

see https://github.com/llvm/llvm-project/issues/213548