### PR TITLE
patch/libpsl: reset to working commit

### DIFF
--- a/patch/0018-libpsl-reset-to-working-commit.patch
+++ b/patch/0018-libpsl-reset-to-working-commit.patch
@@ -1,0 +1,28 @@
+From c84759c521d37eef18ec710e5ea6ccef248fde46 Mon Sep 17 00:00:00 2001
+From: _ <>
+Date: Tue, 4 Aug 2026 00:00:00 +0000
+Subject: [PATCH] libpsl: reset to working commit
+
+---
+ packages/libpsl.cmake | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/packages/libpsl.cmake b/packages/libpsl.cmake
+index f9e0089..9d70ddd 100644
+--- a/packages/libpsl.cmake
++++ b/packages/libpsl.cmake
+@@ -1,8 +1,10 @@
+ ExternalProject_Add(libpsl
+     GIT_REPOSITORY https://github.com/rockdaboot/libpsl.git
+     SOURCE_DIR ${SOURCE_LOCATION}
+-    GIT_CLONE_FLAGS "--depth=1 --sparse --filter=tree:0"
++    GIT_CLONE_FLAGS "--sparse --filter=tree:0"
+     GIT_CLONE_POST_COMMAND "sparse-checkout set --no-cone /* !/fuzz !tests !tools tools/meson.build"
++    GIT_RESET aa3a80e18f25caf3916636c8668dcc0fff7c016d
++    GIT_REMOTE_NAME origin
+     UPDATE_COMMAND ""
+     CONFIGURE_COMMAND ""
+     COMMAND ${EXEC} echo > <SOURCE_DIR>/tools/meson.build
+-- 
+2.55.0
+


### PR DESCRIPTION
see https://github.com/rockdaboot/libpsl/commit/af962fd17821360bcb07a9fee35d6cb4f0b5ead7

libpsl clearly no longer supports cross-compilation. Given that it's irrelevant to mpv's libcurl use case, maybe it should be removed.